### PR TITLE
PR ember-metis + fastboot integration

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -11,6 +11,7 @@ export default class Router extends EmberRouter {
 Router.map(function() {
   this.route("view", function() {}),
 
-  metisFallbackRoute(this);  
   this.route('sparql');
+
+  metisFallbackRoute(this)
 });

--- a/app/router.js
+++ b/app/router.js
@@ -1,5 +1,7 @@
 import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
+import metisFallbackRoute from 'metis/utils/fallback-route';
+import { classRoute } from 'metis/utils/class-route'
 
 export default class Router extends EmberRouter {
   location = config.locationType;
@@ -7,5 +9,8 @@ export default class Router extends EmberRouter {
 }
 
 Router.map(function() {
+  this.route("view", function() {}),
+
+  metisFallbackRoute(this);  
   this.route('sparql');
 });

--- a/config/environment.js
+++ b/config/environment.js
@@ -6,6 +6,10 @@ module.exports = function(environment) {
     environment,
     rootURL: '/',
     locationType: 'auto',
+    metis: {
+      routes: {},
+      baseUrl: "http://data.lblod.info/"
+    },
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/config/environment.js
+++ b/config/environment.js
@@ -8,7 +8,12 @@ module.exports = function(environment) {
     locationType: 'auto',
     metis: {
       routes: {},
-      baseUrl: "http://data.lblod.info/"
+      baseUrl: "http://data.lblod.info/",
+      serverUrl: "http://data.lblod.info/"
+
+    },
+    fastboot: {
+      hostWhitelist: ["localhost:4200","redpencil.io"]
     },
     EmberENV: {
       FEATURES: {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ember-fetch": "^7.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-metis": "git://github.com/redpencilio/ember-metis.git#dev/route-generator",
+    "ember-metis": "git://github.com/redpencilio/ember-metis.git",
     "ember-modifier": "^1.0.3",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^7.18.0",
     "ember-cli-dependency-checker": "^3.2.0",
-    "ember-cli-fastboot": "^2.2.3",
     "ember-cli-htmlbars": "^4.2.3",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
@@ -44,7 +43,6 @@
     "ember-fetch": "^7.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-metis": "git://github.com/redpencilio/ember-metis.git",
     "ember-modifier": "^1.0.3",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^7.0.0",
@@ -65,6 +63,8 @@
     "edition": "octane"
   },
   "dependencies": {
-    "metis": "git://github.com/redpencilio/ember-metis.git#dev/route-generator"
+    "build-url": "^6.0.1",
+    "ember-cli-fastboot": "^2.2.3",
+    "metis": "git://github.com/redpencilio/ember-metis.git#dev/fastboot"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "eslint-plugin-node": "^11.0.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
-    "qunit-dom": "^1.1.0"
+    "qunit-dom": "^1.1.0",
+    "ember-metis": "git://github.com/redpencilio/ember-metis.git#dev/route-generator"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
   },
   "ember": {
     "edition": "octane"
+  },
+  "dependencies": {
+    "metis": "git://github.com/redpencilio/ember-metis.git#dev/route-generator"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^7.18.0",
     "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-fastboot": "^2.2.3",
     "ember-cli-htmlbars": "^4.2.3",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
@@ -43,6 +44,7 @@
     "ember-fetch": "^7.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-metis": "git://github.com/redpencilio/ember-metis.git#dev/route-generator",
     "ember-modifier": "^1.0.3",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^7.0.0",
@@ -54,8 +56,7 @@
     "eslint-plugin-node": "^11.0.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
-    "qunit-dom": "^1.1.0",
-    "ember-metis": "git://github.com/redpencilio/ember-metis.git#dev/route-generator"
+    "qunit-dom": "^1.1.0"
   },
   "engines": {
     "node": "10.* || >= 12"


### PR DESCRIPTION
Momentarilly in package.json , ember-metis gets pulled straight from github repo rather then npm. Ember-metis needs to be published first on npm