### PR TITLE
Update to Appuniversum v1

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,10 +1,6 @@
 /* ==================================
-   #APPUNIVERSUM
+   # Centrale vindplaats
    ================================== */
-
-/**
- * A design universe for Flanders GOV applications
- */
 
 /**
  * CONTENTS
@@ -15,85 +11,19 @@
  * ELEMENTS: Plain html tag styling
  * OBJECTS: OOCSS unstyled objects (namespace: '.au-o-...')
  * COMPONENTS: Components (namespace: '.au-c-...')
+ * PLUGINS: Third-party styles
  * UTILITIES: Single function helper classes (namespace: '.au-u-...')
- * SHAME: Temporary hacks and quickfixes
  */
 
-// VARIABLES
-@import "appuniversum/s-colors";
-@import "appuniversum/s-global";
-@import "appuniversum/s-utilities";
 
-// MIXINS
-@import "appuniversum/t-font-size";
-@import "appuniversum/t-sass-mq";
-
-// GENERIC
-@import "appuniversum/g-reset";
-@import "appuniversum/g-box-sizing";
-// @import "appuniversum/g-font"; // (BREAKING CHANGE | CONFLICT IN FONT WEIGHTS)
-
-// ELEMENTS
-@import "appuniversum/e-page";
-
-// OBJECTS
-@import "appuniversum/o-box";
-@import "appuniversum/o-flow";
-@import "appuniversum/o-grid";
-@import "appuniversum/o-layout";
-@import "appuniversum/o-region";
-
-// WU COMPONENTS (DEPRECATED)
-// @import 'ember-vo-webuniversum-data-table';
-// @import 'ember-vo-webuniversum';
-
-// COMPONENTS
-@import "ember-appuniversum/c-alert";
-@import "ember-appuniversum/c-badge";
-@import "ember-appuniversum/c-body-container";
-@import "ember-appuniversum/c-brand";
-@import "ember-appuniversum/c-button";
-@import "ember-appuniversum/c-button-group";
-@import "ember-appuniversum/c-card";
-@import "ember-appuniversum/c-content";
-@import "ember-appuniversum/c-content-header";
-@import "ember-appuniversum/c-control";
-@import "ember-appuniversum/c-data-table";
-@import "ember-appuniversum/c-dropdown";
-@import "ember-appuniversum/c-form";
-@import "ember-appuniversum/c-heading";
-@import "ember-appuniversum/c-help-text";
-@import "ember-appuniversum/c-hr";
-@import "ember-appuniversum/c-icon";
-@import "ember-appuniversum/c-input";
-@import "ember-appuniversum/c-label";
-@import "ember-appuniversum/c-link";
-@import "ember-appuniversum/c-list-horizontal";
-@import "ember-appuniversum/c-list-navigation";
-@import "ember-appuniversum/c-loader";
-@import "ember-appuniversum/c-pagination";
-@import "ember-appuniversum/c-pill";
-@import "ember-appuniversum/c-main-container";
-@import "ember-appuniversum/c-main-header";
-@import "ember-appuniversum/c-main-footer";
-@import "ember-appuniversum/c-modal";
-@import "ember-appuniversum/c-sidebar";
-@import "ember-appuniversum/c-sidebar-action";
-@import "ember-appuniversum/c-textarea";
-@import "ember-appuniversum/c-toolbar";
-
-// UTILITIES
-@import "appuniversum/u-align-text";
-@import "appuniversum/u-font-family";
-@import "appuniversum/u-font-weights";
-@import "appuniversum/u-headings";
-@import "appuniversum/u-hide";
-@import "appuniversum/u-paragraphs";
-@import "appuniversum/u-print";
-@import "appuniversum/u-responsive-spacings";
-@import "appuniversum/u-spacings";
-@import "appuniversum/u-visible";
-@import "appuniversum/u-widths";
+@import "ember-appuniversum/a-settings";
+@import "ember-appuniversum/a-tools";
+@import "ember-appuniversum/a-generic";
+@import "ember-appuniversum/a-elements";
+@import "ember-appuniversum/a-objects";
+@import "ember-appuniversum/a-components";
+@import "ember-appuniversum/a-plugins";
+@import "ember-appuniversum/a-utilities";
 
 // TEMPORARY HACKS AND QUICKFIXES
 @import 'shame';

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,14 +3,7 @@
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
-  let app = new EmberApp(defaults, {
-    sassOptions: {
-      includePaths: [
-        'node_modules/@appuniversum/appuniversum',
-        'node_modules/@appuniversum/ember-appuniversum/app/styles',
-      ],
-    },
-  });
+  let app = new EmberApp(defaults, {});
 
   // Use `app.import` to add additional libraries to the generated
   // output files.

--- a/package.json
+++ b/package.json
@@ -25,14 +25,18 @@
     "test": "npm-run-all lint test:*",
     "test:ember": "ember test"
   },
+  "overrides": {
+    "@appuniversum/ember-appuniversum": "$@appuniversum/ember-appuniversum"
+  },
+  "overridesComments": {
+    "@appuniversum/ember-appuniversum": "metis has a peerDep on 0.11 which isn't compatible, but it also lists a devDep of v1, so that seems to be a mistake"
+  },
   "devDependencies": {
-    "@appuniversum/appuniversum": "^0.0.14",
-    "@appuniversum/ember-appuniversum": "0.0.30",
+    "@appuniversum/ember-appuniversum": "^1.10.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
-    "@lblod/ember-vo-webuniversum": "^0.22.8",
     "@triply/yasgui": "^4.0.114",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
@@ -69,7 +73,7 @@
     "eslint-plugin-prettier": "^3.4.1",
     "eslint-plugin-qunit": "^6.2.0",
     "loader.js": "^4.7.0",
-    "metis": "github:redpencilio/ember-metis#v0.3.2",
+    "metis": "github:redpencilio/ember-metis#v0.5.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.5.1",
     "qunit": "^2.17.2",


### PR DESCRIPTION
This updates to v1.10.0 release which was the last v1 release. We can then start fixing deprecations and update to v2.

This release includes the Webuniversum v3-like styling so everything looks more modern.