### PR TITLE
Temporarily disable Embroider

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,20 +5,20 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {});
 
-  // Uncomment this to do a non-Embroider build
-  // return app.toTree();
+  // Comment/Uncomment this to enable/disable Embroider build
+  return app.toTree();
 
-  const { Webpack } = require('@embroider/webpack');
-  return require('@embroider/compat').compatBuild(app, Webpack, {
-    staticAddonTestSupportTrees: true,
-    staticAddonTrees: true,
-    staticHelpers: true,
-    staticModifiers: true,
-    staticComponents: true,
-    // staticEmberSource: true,
-    // splitAtRoutes: ['route.name'], // can also be a RegExp
-    // packagerOptions: {
-    //    webpackConfig: { }
-    // }
-  });
+  // const { Webpack } = require('@embroider/webpack');
+  // return require('@embroider/compat').compatBuild(app, Webpack, {
+  //   staticAddonTestSupportTrees: true,
+  //   staticAddonTrees: true,
+  //   staticHelpers: true,
+  //   staticModifiers: true,
+  //   staticComponents: true,
+  //   // staticEmberSource: true,
+  //   // splitAtRoutes: ['route.name'], // can also be a RegExp
+  //   // packagerOptions: {
+  //   //    webpackConfig: { }
+  //   // }
+  // });
 };


### PR DESCRIPTION
The production build seems to fail with the following error:

> Error: Could not find module `frontend-centrale-vindplaats/app` imported from `~fastboot/app-factory`

This doesn't happen in the dev build, which is why we didn't notice.

So we disable Embroider until we find a solution.